### PR TITLE
Update chassis offset handling

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -20,20 +20,10 @@ import edu.wpi.first.wpilibj.I2C;
 public final class Constants {
     public static final class DriveConstants {
 
-        /**
-         * The Order from top to bottom is:
-         * Front Left,
-         * Rear Left,
-         * Front Right,
-         * Rear Right
-         * */
-
-        public static final double[] ENCODER_OFFSETS = {
-                Math.PI - Math.toRadians(187.5),
-                Math.toRadians(358.9),
-                Math.PI + Math.toRadians(160.54),
-                Math.PI - Math.toRadians(185.4)
-        };
+        public static final double FRONT_LEFT_ENCODER_OFFSET = Math.toRadians(-7.50);
+        public static final double REAR_LEFT_ENCODER_OFFSET = Math.toRadians(-1.10);
+        public static final double FRONT_RIGHT_ENCODER_OFFSET = Math.toRadians(-19.46);
+        public static final double REAR_RIGHT_ENCODER_OFFSET = Math.toRadians(-5.40);
 
         public static final int FRONT_LEFT_DRIVE_MOTOR_PORT = 4;
         public static final int REAR_LEFT_DRIVE_MOTOR_PORT = 5;

--- a/src/main/java/frc/robot/subsystems/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DriveSubsystem.java
@@ -26,25 +26,25 @@ public class DriveSubsystem extends SubsystemBase {
 			new SwerveModule(
 					DriveConstants.FRONT_LEFT_DRIVE_MOTOR_PORT,
 					DriveConstants.FRONT_LEFT_TURNING_MOTOR_PORT,
-							DriveConstants.ENCODER_OFFSETS[0], true);
+					DriveConstants.FRONT_LEFT_ENCODER_OFFSET, true);
 
 	public final SwerveModule rearLeft =
 			new SwerveModule(
 					DriveConstants.REAR_LEFT_DRIVE_MOTOR_PORT,
 					DriveConstants.REAR_LEFT_TURNING_MOTOR_PORT,
-							DriveConstants.ENCODER_OFFSETS[1], true);
+					DriveConstants.REAR_LEFT_ENCODER_OFFSET, true);
 
 	public final SwerveModule frontRight =
 			new SwerveModule(
 					DriveConstants.FRONT_RIGHT_DRIVE_MOTOR_PORT,
 					DriveConstants.FRONT_RIGHT_TURNING_MOTOR_PORT,
-							DriveConstants.ENCODER_OFFSETS[2], true);
+					DriveConstants.FRONT_RIGHT_ENCODER_OFFSET, true);
 
 	public final SwerveModule rearRight =
 			new SwerveModule(
 					DriveConstants.REAR_RIGHT_DRIVE_MOTOR_PORT,
 					DriveConstants.REAR_RIGHT_TURNING_MOTOR_PORT,
-							DriveConstants.ENCODER_OFFSETS[3], true);
+					DriveConstants.REAR_RIGHT_ENCODER_OFFSET, true);
 
 	// The gyro sensor
 	private final PigeonIMU gyro = new PigeonIMU(30);


### PR DESCRIPTION
First, the offsets are just harder to keep track of in an array. You can't look at the code where they're used and know that you're using the right one just by the array index.  So I've split them out into separate constants, consistent with how the ports and encoders are named.

Also, I've mathed out each offset value so they're just a numerical offset, in degrees (and a conversion to radians).