### PR TITLE
Found an issue with the use of ResetGyro, which was only returning...

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -50,7 +50,7 @@ public class Robot extends TimedRobot {
     modeChooser.addOption("Center", AutoMode.CENTER);
     modeChooser.addOption("Right", AutoMode.RIGHT);
 
-    robotContainer.robotDrive.ResetGyro();
+    // robotContainer.robotDrive.zeroHeading(); // probably not needed any more -- test for certainty
 
   }
 
@@ -96,7 +96,6 @@ public class Robot extends TimedRobot {
   @Override 
   public void autonomousInit() 
   {
-    robotContainer.robotDrive.ResetGyro();
     System.out.println(modeChooser.getSelected());
     System.out.println(allianceChooser.getSelected());
     robotContainer.auto((AutoMode)modeChooser.getSelected(), (Alliance)allianceChooser.getSelected()).schedule();

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -140,7 +140,7 @@ public class RobotContainer extends SubsystemBase {
    */
   private void configureButtonBindings() 
   {
-    driverController.button(7).and(driverController.button(8)).whileTrue(robotDrive.ResetGyro());
+    driverController.button(7).and(driverController.button(8)).whileTrue(robotDrive.getZeroHeadingCommand());
     ///driverController.leftBumper().whileTrue(robotDrive.SlowSwerve());
     //driverController.leftBumper().whileFalse(robotDrive.NormalSwerve());
 

--- a/src/main/java/frc/robot/subsystems/DriveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/DriveSubsystem.java
@@ -72,6 +72,8 @@ public class DriveSubsystem extends SubsystemBase {
 
 	/** Creates a new DriveSubsystem. */
 	public DriveSubsystem() {
+                gyro.setYaw(0);
+
 		AutoBuilder.configureHolonomic(
 			this::getPose,
 			this::resetPose,
@@ -85,10 +87,10 @@ public class DriveSubsystem extends SubsystemBase {
 		);
 	}
 
-	public Command ResetGyro()
+	public Command getZeroHeadingCommand()
 	{
 		return this.runOnce(() -> {
-			gyro.setYaw(0);
+			this.zeroHeading();
 		});
 	}
 


### PR DESCRIPTION
Found an issue with the use of ResetGyro, which was only returning...

...a Command object that would reset the gyro if called, which is fine
for what appears to be its original use -- binding it to a button
-- but was not sufficient for calling from robotInit.  Also found
the zeroHeading method, which zeroes the yaw directly.

Refactored with the following:
  * added call to zeroHeading in DriveSubsystem constructor
  * removed gyro reset from robotInit and autonomousInit
  * renamed GyroReset to getZeroHeadingCommand
  * changed getZeroHeadingCommand to call zeroHeading rather
    than access gyro directly

Needs testing.