### PR TITLE
This change implements a round deadband on the X/Y stick.

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -186,6 +186,7 @@ public final class Constants {
     public static final class ShooterConstants
     {
         public static final double FEEDER_SPEED = 0.55;
+        public static final double FEEDER_FORWARD_SPEED = 0.15;
         public static final double SHOOTER_REVERSE_SPEED = 0.2;
         public static final double SPEAKER_SPEED = 0.65;
         public static final double AMP_SPEED = 0.4;
@@ -196,6 +197,7 @@ public final class Constants {
         public static final double INTAKING_SPEED = 0.4;
         public static final double POSITIONING_SPEED = 0.35;
         public static final double FEEDER_SPEED = 0.3;
+        public static final double FEEDER_FORWARD_SPEED = 0.15; // TODO: fix all these dumbass naming conventions
     }
 
     public static final class ElevatorConstants

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -163,7 +163,7 @@ public final class Constants {
 
     public static final class AutoConstants {
         public static final boolean SWITCH_ALLIANCE = false; // switches auto origin between red and blue alliance, default blue-origin
-        public static final double MAX_SPEED_METERS_PER_SECOND = 8;
+        public static final double MAX_SPEED_METERS_PER_SECOND = 10;
         public static final double MAX_ACCELERATION_METERS_PER_SECOND_SQUARED = 3;
         public static final double MAX_ANGULAR_SPEED_RADIANS_PER_SECOND = Math.PI;
         public static final double MAX_ANGULAR_SPEED_RADIANS_PER_SECOND_SQUARED = Math.PI;

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -152,7 +152,7 @@ public final class Constants {
         public static final double kTurningEncoderPositionPIDMinInput = 0; // radians
         public static final double kTurningEncoderPositionPIDMaxInput = 2 * Math.PI; // radians
                 
-        public static final double DEADBAND = 0.2;
+        public static final double DEADBAND = 0.15;
 
     }
 

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -80,9 +80,16 @@ public class RobotContainer extends SubsystemBase {
               double yInput = driverController.getLeftY();
               double thetaInput = driverController.getRawAxis(4);
 
+              // Apply a round deadband, based on the x/y distance from the origin
+              double distanceFromZero = Math.sqrt(Math.pow(xInput, 2) + Math.pow(yInput, 2)); // Pythagoras
+              if (distanceFromZero < ModuleConstants.DEADBAND) {
+                  xInput = 0;
+                  yInput = 0;
+              }
+
               robotDrive.drive(
-                  Math.pow(MathUtil.applyDeadband(-yInput, ModuleConstants.DEADBAND), 3) * Math.abs(yInput),
-                  Math.pow(MathUtil.applyDeadband(-xInput, ModuleConstants.DEADBAND), 3) * Math.abs(xInput),
+                  Math.pow(-yInput, 3) * Math.abs(yInput),
+                  Math.pow(-xInput, 3) * Math.abs(xInput),
                   Math.pow(MathUtil.applyDeadband(-thetaInput, ModuleConstants.DEADBAND), 3) * Math.abs(thetaInput),
                   true);
             },

--- a/src/main/java/frc/robot/subsystems/IntakeSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/IntakeSubsystem.java
@@ -37,7 +37,7 @@ public class IntakeSubsystem extends SubsystemBase
         return this.runOnce(() -> {
             intakingMotor.set(IntakeConstants.INTAKING_SPEED);
             positioningMotor.set(IntakeConstants.POSITIONING_SPEED);
-            feederMotor.set(-IntakeConstants.FEEDER_SPEED);
+            feederMotor.set(-IntakeConstants.FEEDER_FORWARD_SPEED);
         });
     };
 

--- a/src/main/java/frc/robot/subsystems/ShooterSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/ShooterSubsystem.java
@@ -24,7 +24,7 @@ public class ShooterSubsystem extends SubsystemBase {
         shooterLeft = new CANSparkMax(DriveConstants.LEFT_SHOOTER_MOTOR_PORT,
         MotorType.kBrushless);
         shooterRight = new CANSparkMax(DriveConstants.RIGHT_SHOOTER_MOTOR_PORT,
-        MotorType.kBrushless);        
+        MotorType.kBrushless);     
         // robotPositonToApril = new Pose3d();
 
         shooterLeft.setSmartCurrentLimit(80);
@@ -61,7 +61,7 @@ public class ShooterSubsystem extends SubsystemBase {
     public Command FeederMotorForward()
     {
         return this.runOnce(() -> {
-            feederMotor.set(-ShooterConstants.FEEDER_SPEED);
+            feederMotor.set(-ShooterConstants.FEEDER_FORWARD_SPEED);
         });
     }   
 


### PR DESCRIPTION
The previous way resulted in a square deadband, which makes for a larger deadband on the 45deg diagonals.  With the deadband value we're using (0.2), this means the diagonal deadband comes to 0.28, which is close to 1/3 of the range available.

Worth testing out if we have time.

It may also be worth reducing the deadband a bit -- like from 0.2 to 0.15?